### PR TITLE
Access multiple local storage keys with an object query

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A React hook to access `localStorage`.
 Using `npm`:
 
 ```sh
-npm install --save react-hook-local-web-storage
+npm install react-hook-local-web-storage
 ```
 
 Using `yarn`:
@@ -18,101 +18,195 @@ yarn add react-hook-local-web-storage
 
 ## Basic usage
 
-The `useLocalStorage()` hook, similarly to the `useState()` hook, returns an array of two elements:
+The `useLocalStorage` hook, similarly to the `useState` hook, returns an array of two elements:
 
-- the first element contains the value stored in `localStorage`, which is getting updated at regular intervals.
+- The first element contains the value stored in `localStorage`.
 
-- the second element is a function which can be called with a value that will be stored in `localStorage`. If you call this function without an argument, the `localStorage` entry will be removed.
+- The second element is a function which can be called with a value which will be converted to string and stored in `localStorage`. If this function is called without an argument, or with the argument `null` or `undefined`, the `localStorage` entry will be removed.
 
-The key to the `localStorage` entry you want to access must be supplied to the hook as its first argument:
+The key to the `localStorage` entry you want to access must be supplied to the hook as its first argument.
+
+For example:
 
 ```jsx
-import React from 'react'
-import useLocalStorage from 'react-hook-local-web-storage'
+import useLocalStorage from "react-hook-local-web-storage";
 
 const ComponentWithLocalStorage = () => {
-  const [value, setValue] = useLocalStorage('myKey')
+  const [value, setValue] = useLocalStorage("myKey");
 
   return (
     <div className="App">
       <p>Value in LocalStorage: {value}</p>
       <button
-        onClick={() => setValue('Value from hook')}
+        onClick={() => {
+          setValue("Value from hook");
+        }}
       >
-        Set value with hook
+        Set myKey
       </button>
       <button
-        onClick={() => setValue()}
+        onClick={() => {
+          setValue(null);
+        }}
       >
-        Unset value
+        Unset myKey
       </button>
     </div>
-  )
-}
+  );
+};
 ```
 
-### Tweaking the update frequency
+## Using multiple `localStorage` entires
 
-The default update frequency of the `localStorage` content is 1 second which can be overridden by calling `useLocalStorage()` with a second argument which is an options object, and has a member called `updateFrequency` that indicates the desired update frequency in milliseconds:
+The `useLocalStorage` hook can work with multiple `localStorage` entries simultaneously.
 
-```jsx
-const [value, setValue] = useLocalStorage(
-  'myKey',
-  {updateFrequency: 500}
-)
-```
+In order to achieve this, the first argument specified when calling the hook must be an object instead of a string. The keys of the object will represent the `localStorage` entry keys used by the hook. The values specified in this object will be ignored, in order to avoid confusion, it is recommended to use `null` as values.
 
-Read more about syncing in [Caveats](#caveats).
+If the `useLocalStorage` hook is called like this, the array it returns will contain two elements:
 
-### Caveats
+- The first element is an object which contains all values in the `localStorage` by the keys specified in the object the hook was called with.
 
-This hook is accessing `localStorage` content at regular intervals, which can result in a delay in registering changes and lead to performance issues if the update frequency is low.
+- The second element is a function which expects an object as a parameter, in which the keys must be a subset of the keys of the object the hook was called with. Every `localStorage` entry corresponding to a key in this object will be set to the value specified by that key (converted to string). If the value by any key is `null` or `undefined`, the corresponding `localStorage` entry will be unset.
 
-You can opt out from periodically reading from `localStorage` using the `useLocalStorageNoSync()` hook instead. Read more about this in [Disable syncing](#disable-syncing).
-
-## Disable syncing
-
-In case you don't want the hook to automatically react to changes in `localStorage`, you can import and use the `useLocalStorageNoSync()` hook, which lets you use `localStorage` without continuous synchronization. The `useLocalStorageNoSync()` hook returns an array of two elements:
-
-- the first element is a function that returns value stored in `localStorage`. This triggers synchronization on demand (when you call it, typically when the component renders).
-
-- the second element is a function which can be called with a value that will be stored in `localStorage`. If you call this function without an argument, the `localStorage` entry will be removed.
-
-The key to the `localStorage` entry you want to access must be supplied to the hook as its first argument:
+For example:
 
 ```jsx
-import React from 'react'
-import {useLocalStorageNoSync as useLocalStorage} from 'react-hook-local-web-storage'
+import useLocalStorage from "react-hook-local-web-storage";
 
 const ComponentWithLocalStorage = () => {
-  const [getValue, setValue] = useLocalStorage('myKey')
+  const [values, setValues] = useLocalStorage({
+    myKey: null,
+    myOtherKey: null,
+  });
+
+  const { myKey, myOtherKey } = values;
 
   return (
     <div className="App">
-      <p>Value in LocalStorage: {getValue()}</p>
+      <p>
+        Values in LocalStorage: {myKey}, {myOtherKey}
+      </p>
       <button
-        onClick={() => setValue('Value from hook')}
+        onClick={() => {
+          setValues({ myKey: "Setting myKey from hook" });
+        }}
+      >
+        Set myKey, leave myOtherKey intact
+      </button>
+      <button
+        onClick={() => {
+          setValues({ myOtherKey: "Setting myOtherKey from hook" });
+        }}
+      >
+        Set myOtherKey, leave myKey intact
+      </button>
+      <button
+        onClick={() => {
+          setValues({
+            myKey: "Setting myKey from hook",
+            myOtherKey: "Setting myOtherKey from hook",
+          });
+        }}
+      >
+        Set both myKey and myOtherKey
+      </button>
+      <button
+        onClick={() => {
+          setValues({
+            myKey: null,
+          });
+        }}
+      >
+        Unset myKey, leave myOtherKey intact
+      </button>
+      <button
+        onClick={() => {
+          setValues({
+            myOtherKey: null,
+          });
+        }}
+      >
+        Unset myOtherKey, leave myKey intact
+      </button>
+      <button
+        onClick={() => {
+          setValues({
+            myKey: "Setting myKey from hook",
+            myOtherKey: null,
+          });
+        }}
+      >
+        Set myKey and unset myOtherKey
+      </button>
+      <button
+        onClick={() => {
+          setValues({
+            myKey: null,
+            myOtherKey: null,
+          });
+        }}
+      >
+        Unset both myKey and myOtherKey
+      </button>
+    </div>
+  );
+};
+```
+
+## Enable syncing
+
+By default `localStorage` will be accessed only once when the component using the hook is mounted.
+
+The hook can be configured to automatically react to changes of the `localStorage` entry or entries by calling it with a second `options` parameter, in which by the key `syncFrequency` the frequency of reading the data from `localStorage` can be specified in milliseconds.
+
+This feature works the same way whether the hook is used with a single `localStorage` entry or multiple entires.
+
+For example:
+
+```jsx
+import useLocalStorage from "react-hook-local-web-storage";
+
+const ComponentWithLocalStorage = () => {
+  const [value, setValue] = useLocalStorage("myKey", { syncFrequency: 1000 });
+
+  return (
+    <div className="App">
+      <p>Value in LocalStorage: {value}</p>
+      <button
+        onClick={() => {
+          setValue("Value from hook");
+        }}
       >
         Set value with hook
       </button>
       <button
-        onClick={() => setValue()}
+        onClick={() => {
+          setValue(null);
+        }}
       >
         Unset value
       </button>
     </div>
-  )
-}
+  );
+};
 ```
+
+Be aware that when the hook is used like this, the component will access `localStorage` at regular intervals, which can result in a delay in registering changes and lead to performance issues if the update frequency is low.
 
 ## Limitations
 
-`localStorage` is using the Storage interface of the Web Storage API that requires all keys and values to be strings.
+`localStorage` is using the Storage interface of the Web Storage API which requires all keys and values to be strings.
+
+## Migrating from 1.x.x
+
+If you were using default import, remember to specify the `syncFrequency` in the second `options` parameter when calling the hook to keep syncing with `localStorage`.
+
+If you were using the named import `useLocalStorageNoSync`, simply switch to default import.
 
 ## Contributions
 
 Contributions are welcome. File bug reports, create pull requests, feel free to reach out at tothab@gmail.com.
 
-## Licence
+## License
 
-LGPL-3.0
+`react-hook-local-web-storage` is licensed under [LGPL](./LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-hook-local-web-storage",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.2",
+      "version": "2.0.0",
       "license": "LGPL-3.0",
       "devDependencies": {
         "@babel/cli": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-local-web-storage",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "A React hook for accessing localStorage",
   "keywords": [
     "react",

--- a/src/index.js
+++ b/src/index.js
@@ -40,9 +40,14 @@ const useLocalStorage = (key, { updateFrequency = 1000 } = {}) => {
 };
 
 const useManyInLocalStorage = (keys, { updateFrequency = 1000 } = {}) => {
+  /*So that local storage keys are still easily accessed compared to vanilla React
+ without having to call useLocalStorage multiple times*/
+
   const [values, setValues] = useState(keys);
 
   const writeObjectToLocalStorage = (newValues) => {
+    //Example use: setStorage({name:"Luke", lastName:"Skywalker"});
+
     for (const [key, value] of Object.entries(newValues)) {
       if (value !== undefined) {
         localStorage.setItem(key, value);
@@ -110,17 +115,6 @@ const useLocalStorageNoSync = (key) => {
 const useManyNoSync = (keys) => {
   const [values, setValues] = useState(keys);
 
-  const writeObjectToLocalStorage = (newValues) => {
-    for (const [key, value] of Object.entries(newValues)) {
-      if (value !== undefined) {
-        localStorage.setItem(key, value);
-      } else {
-        localStorage.removeItem(key);
-      }
-    }
-    setValues(newValues);
-  };
-
   const readFromLocalStorage = () => {
     for (const [key, oldValue] of Object.entries(values)) {
       const newValue = localStorage.getItem(key);
@@ -131,6 +125,17 @@ const useManyNoSync = (keys) => {
       }
     }
     return values;
+  };
+
+  const writeObjectToLocalStorage = (newValues) => {
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value !== undefined) {
+        localStorage.setItem(key, value);
+      } else {
+        localStorage.removeItem(key);
+      }
+    }
+    setValues(newValues);
   };
 
   return [readFromLocalStorage, writeObjectToLocalStorage];

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,35 @@ const useLocalStorageNoSync = (key) => {
   return [readFromLocalStorage, writeToLocalStorage];
 };
 
+const useManyNoSync = (keys) => {
+  const [values, setValues] = useState(keys);
+
+  const writeObjectToLocalStorage = (newValues) => {
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value !== undefined) {
+        localStorage.setItem(key, value);
+      } else {
+        localStorage.removeItem(key);
+      }
+    }
+    setValues(newValues);
+  };
+
+  const readFromLocalStorage = () => {
+    for (const [key, oldValue] of Object.entries(values)) {
+      const newValue = localStorage.getItem(key);
+      if (newValue !== oldValue) {
+        setValues((prev) => {
+          return { ...prev, key: newValue };
+        });
+      }
+    }
+    return values;
+  };
+
+  return [readFromLocalStorage, writeObjectToLocalStorage];
+};
+
 export default useLocalStorage;
 
-export { useLocalStorageNoSync, useManyInLocalStorage };
+export { useLocalStorageNoSync, useManyInLocalStorage, useManyNoSync };

--- a/src/index.js
+++ b/src/index.js
@@ -1,70 +1,109 @@
-import {useState, useEffect} from 'react'
+import { useState, useEffect } from "react";
 
-const useLocalStorage = (key, {updateFrequency = 1000} = {}) => {
-  const [value, setValue] = useState()
+const useLocalStorage = (key, { updateFrequency = 1000 } = {}) => {
+  const [value, setValue] = useState();
 
-  const writeToLocalStorage = newValue => {
+  const writeToLocalStorage = (newValue) => {
     if (newValue !== undefined) {
-      localStorage.setItem(key, newValue)
+      localStorage.setItem(key, newValue);
+    } else {
+      localStorage.removeItem(key);
     }
-    else {
-      localStorage.removeItem(key)
-    }
-    setValue(newValue)
-  }
+    setValue(newValue);
+  };
 
   useEffect(() => {
     const readFromLocalStorage = () => {
-      const oldValue = value
-      const newValue = localStorage.getItem(key)
+      const oldValue = value;
+      const newValue = localStorage.getItem(key);
       if (newValue !== oldValue) {
-        setValue(newValue)
+        setValue(newValue);
       }
-    }
+    };
 
-    let readLocalStorageIntervalId
+    let readLocalStorageIntervalId;
     if (window.localStorage) {
-      readFromLocalStorage()
+      readFromLocalStorage();
       readLocalStorageIntervalId = setInterval(
         readFromLocalStorage,
         updateFrequency
-      )
+      );
     }
     return () => {
       if (window.localStorage) {
-        clearInterval(readLocalStorageIntervalId)
+        clearInterval(readLocalStorageIntervalId);
       }
+    };
+  }, [key, value, updateFrequency]);
+
+  return [value, writeToLocalStorage];
+};
+
+const useManyInLocalStorage = (keys, { updateFrequency = 1000 } = {}) => {
+  const [values, setValues] = useState();
+
+  const writeToLocalStorage = (newValues) => {
+    for (const [key, value] of Object.entries(keys)) {
+      if (newValues[key] !== undefined) {
+        localStorage.setItem(key, newValues[key]);
+      } else {
+        localStorage.removeItem(key);
+      }
+      setValues(newValues);
     }
-  }, [key, value, updateFrequency])
+  };
 
-  return [value, writeToLocalStorage]
-}
+  useEffect(() => {
+    const readFromLocalStorage = () => {
+      const oldValue = [...values];
+      const newValue = localStorage.getItem(key);
+      if (newValue !== oldValue) {
+        setValues(newValue);
+      }
+    };
 
-const useLocalStorageNoSync = key => {
-  const [value, setValue] = useState()
+    let readLocalStorageIntervalId;
+    if (window.localStorage) {
+      readFromLocalStorage();
+      readLocalStorageIntervalId = setInterval(
+        readFromLocalStorage,
+        updateFrequency
+      );
+    }
+    return () => {
+      if (window.localStorage) {
+        clearInterval(readLocalStorageIntervalId);
+      }
+    };
+  }, [key, value, updateFrequency]);
+
+  return [value, writeToLocalStorage];
+};
+
+const useLocalStorageNoSync = (key) => {
+  const [value, setValue] = useState();
 
   const readFromLocalStorage = () => {
-    const oldValue = value
-    const newValue = localStorage.getItem(key)
+    const oldValue = value;
+    const newValue = localStorage.getItem(key);
     if (newValue !== oldValue) {
-      setValue(newValue)
+      setValue(newValue);
     }
-    return newValue
-  }
+    return newValue;
+  };
 
-  const writeToLocalStorage = newValue => {
+  const writeToLocalStorage = (newValue) => {
     if (newValue !== undefined) {
-      localStorage.setItem(key, newValue)
+      localStorage.setItem(key, newValue);
+    } else {
+      localStorage.removeItem(key);
     }
-    else {
-      localStorage.removeItem(key)
-    }
-    setValue(newValue)
-  }
+    setValue(newValue);
+  };
 
-  return [readFromLocalStorage, writeToLocalStorage]
-}
+  return [readFromLocalStorage, writeToLocalStorage];
+};
 
-export default useLocalStorage
+export default useLocalStorage;
 
-export {useLocalStorageNoSync}
+export { useLocalStorageNoSync, useManyInLocalStorage };

--- a/src/index.js
+++ b/src/index.js
@@ -40,25 +40,28 @@ const useLocalStorage = (key, { updateFrequency = 1000 } = {}) => {
 };
 
 const useManyInLocalStorage = (keys, { updateFrequency = 1000 } = {}) => {
-  const [values, setValues] = useState();
+  const [values, setValues] = useState(keys);
 
   const writeToLocalStorage = (newValues) => {
-    for (const [key, value] of Object.entries(keys)) {
-      if (newValues[key] !== undefined) {
-        localStorage.setItem(key, newValues[key]);
+    for (const [key, value] of Object.entries(newValues)) {
+      if (value !== undefined) {
+        localStorage.setItem(key, value);
       } else {
         localStorage.removeItem(key);
       }
-      setValues(newValues);
     }
+    setValues(newValues);
   };
 
   useEffect(() => {
     const readFromLocalStorage = () => {
-      const oldValue = [...values];
-      const newValue = localStorage.getItem(key);
-      if (newValue !== oldValue) {
-        setValues(newValue);
+      for (const [key, oldValue] of Object.entries(values)) {
+        const newValue = localStorage.getItem(key);
+        if (newValue !== oldValue) {
+          setValues((prev) => {
+            return { ...prev, key: newValue };
+          });
+        }
       }
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const useLocalStorage = (key, { updateFrequency = 1000 } = {}) => {
 const useManyInLocalStorage = (keys, { updateFrequency = 1000 } = {}) => {
   const [values, setValues] = useState(keys);
 
-  const writeToLocalStorage = (newValues) => {
+  const writeObjectToLocalStorage = (newValues) => {
     for (const [key, value] of Object.entries(newValues)) {
       if (value !== undefined) {
         localStorage.setItem(key, value);
@@ -80,7 +80,7 @@ const useManyInLocalStorage = (keys, { updateFrequency = 1000 } = {}) => {
     };
   }, [key, value, updateFrequency]);
 
-  return [value, writeToLocalStorage];
+  return [value, writeObjectToLocalStorage];
 };
 
 const useLocalStorageNoSync = (key) => {


### PR DESCRIPTION
**Summary**

I notice that there is no current option to access multiple keys with the useLocalStorage hooks. 

This pull request includes a sync and no-sync version of accessing multiple storage keys with an object version of writeToLocalStorage. This is a convenient feature to add for quickly changing those values without creating multiple instances of the hook.

I wrote it and exported them as a separate functions as to not interfere with the original idea and organized them similarly to the other hooks.